### PR TITLE
Fix golangci-lint installation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,6 @@ jobs:
         uses: GusAntoniassi/action-setup-golangci-lint@master
         with:
           version: 1.24.0
+
+      - name: Validate
+        run: golangci-lint --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,15 +3,10 @@ on: [push]
 jobs:
   test_action:
     runs-on: ubuntu-latest
-    name: Test action
+    name: Test this action
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v1
-        with:
-          go-version: "1.14"
-
       - name: Test action
         id: test-action
-        uses: GusAntoniassi/action-setup-golangci-lint@master
+        uses: $GITHUB_REPOSITORY@master
         with:
           version: 1.24.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+on: [push]
+
+jobs:
+  test_action:
+    runs-on: ubuntu-latest
+    name: Test action
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+
+      - name: Test action
+        id: test-action
+        uses: GusAntoniassi/action-setup-golangci-lint@master
+        with:
+          version: 1.24.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - name: Test action
         id: test-action
-        uses: GusAntoniassi/action-setup-golangci-lint@master
+        uses: nickhstr/action-setup-golangci-lint@v0.2.0
         with:
           version: 1.24.0
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
       - name: Test action
         id: test-action
-        uses: $GITHUB_REPOSITORY@master
+        uses: GusAntoniassi/action-setup-golangci-lint@master
         with:
           version: 1.24.0

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ golangci-lint is downloaded and added to the tools cache for reuse across jobs/s
 
 ## Inputs
 Only one input is needed: `version`. This must be a semantic version, matching a released version of golangci-lint.
+
+## Example usage
+
+```yaml
+uses: nickhstr/action-setup-golangci-lint@v0.2.0
+with:
+    version: 1.24.0
+```

--- a/src/installer.js
+++ b/src/installer.js
@@ -29,8 +29,8 @@ async function installer(version) {
   // Add golangci-lint dir to bin
   core.addPath(toolRoot);
 
-  // let g = await io.which('golangci-lint', true);
-  // core.debug(`which golangci-lint: ${g}`)
+  let g = await io.which('golangci-lint', true);
+  core.debug(`which golangci-lint: ${g}`)
 }
 
 /**

--- a/src/installer.js
+++ b/src/installer.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
+const io = require('@actions/io');
 
 const toolName = 'golangci-lint';
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -23,8 +23,14 @@ async function installer(version) {
     core.debug(`${toolName} is cached under ${toolPath}`);
   }
 
+  // Tool will be extracted in a directory with the compressed file name
+  toolRoot = path.join(toolPath, `golangci-lint-${version}-linux-amd64`)
+
   // Add golangci-lint dir to bin
-  core.addPath(toolPath);
+  core.addPath(toolRoot);
+
+  // let g = await io.which('golangci-lint', true);
+  // core.debug(`which golangci-lint: ${g}`)
 }
 
 /**


### PR DESCRIPTION
Hello, I wasn't able to use this action because the golangci-lint tool apparently wasn't being in the PATH.

I have done some debugging, ran some `ls -lah` inside the job, and compared with the [`actions/setup-go`](https://github.com/actions/setup-go/blob/master/src/installer.ts) installer, and found out the tool was being extracted in a `golangci-lint-${version}-linux-amd64` directory.

I have added the following code to add the correct directory to PATH: 
```js
  // Tool will be extracted in a directory with the compressed file name
  toolRoot = path.join(toolPath, `golangci-lint-${version}-linux-amd64`)

  // Add golangci-lint dir to bin
  core.addPath(toolRoot);
```

I have also added some extra things like a `which` and a `golangci-lint --version` command to validate the tool instalation, and some usage documentation in the README.md.

Any feedback is much appreciated.